### PR TITLE
feat: add orange & teal filter

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -1,4 +1,5 @@
 import { showToast } from './toast.js';
+import { applyOrangeTealFilter } from './filters/orangeTeal.js';
 
 export function initFilters(elements, state) {
   elements.filterItems.forEach(item => {
@@ -68,6 +69,10 @@ function applyFilterAdjustment(elements, state) {
     state.appliedFilters[existingFilterIndex] = { ...state.currentFilter, settings: { ...state.filterSettings } };
   } else {
     state.appliedFilters.push({ ...state.currentFilter, settings: { ...state.filterSettings } });
+  }
+  if (state.currentFilter.id === 'orange-teal') {
+    applyOrangeTealFilter(elements.previewImage);
+    state.currentImage = elements.previewImage.src;
   }
   state.previousSettings = null;
   closeAdjustmentPanel(elements);


### PR DESCRIPTION
## Summary
- implement Orange & Teal color grading filter in JavaScript
- integrate filter into existing adjustment workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2dc6494832d9b9913504dfedc78