### PR TITLE
Enable live Orange & Teal filter preview

### DIFF
--- a/js/imageActions.js
+++ b/js/imageActions.js
@@ -23,7 +23,7 @@ function resetImage(elements, state) {
   state.appliedFilters = [];
   elements.filterItems.forEach(item => item.classList.remove('active'));
   state.currentFilter = null;
-  closeAdjustmentPanel(elements);
+  closeAdjustmentPanel(elements, state);
   showToast('Image reset successfully', 'success');
 }
 
@@ -36,6 +36,6 @@ function newProject(elements, state) {
   elements.previewImage.style.display = 'none';
   elements.dropArea.style.display = 'flex';
   elements.filterItems.forEach(item => item.classList.remove('active'));
-  closeAdjustmentPanel(elements);
+  closeAdjustmentPanel(elements, state);
   showToast('New project created', 'success');
 }


### PR DESCRIPTION
## Summary
- Add intensity, contrast, and brightness controls to the Orange & Teal filter
- Render filter preview as sliders move and reset preview when closing adjustments
- Clean up image actions to respect the new close panel behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb57c0b34832d8e3fdb16101e161e