### PR TITLE
Fix Orange & Teal preview and slider logic

### DIFF
--- a/js/imageActions.js
+++ b/js/imageActions.js
@@ -23,7 +23,7 @@ function resetImage(elements, state) {
   state.appliedFilters = [];
   elements.filterItems.forEach(item => item.classList.remove('active'));
   state.currentFilter = null;
-  closeAdjustmentPanel(elements);
+  closeAdjustmentPanel(elements, state);
   showToast('Image reset successfully', 'success');
 }
 
@@ -36,6 +36,6 @@ function newProject(elements, state) {
   elements.previewImage.style.display = 'none';
   elements.dropArea.style.display = 'flex';
   elements.filterItems.forEach(item => item.classList.remove('active'));
-  closeAdjustmentPanel(elements);
+  closeAdjustmentPanel(elements, state);
   showToast('New project created', 'success');
 }

--- a/js/state.js
+++ b/js/state.js
@@ -7,5 +7,6 @@ export const state = {
     brightness: 0
   },
   previousSettings: null,
-  appliedFilters: []
+  appliedFilters: [],
+  previewBaseImage: null
 };


### PR DESCRIPTION
## Summary
- Apply Orange & Teal filter with adjustable intensity, contrast and brightness
- Preview Orange & Teal effect without stacking by keeping original image reference
- Reset preview correctly in image reset/new project actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adba1d0b1c832dbc110eee888bb446