### PR TITLE
Render filter preview only after slider release

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -14,13 +14,25 @@ export function initFilters(elements, state) {
   elements.applyAdjustment.addEventListener('click', () => applyFilterAdjustment(elements, state));
   elements.intensitySlider.addEventListener('input', () => {
     updateIntensityValue(elements);
+    // previewCurrentFilter(elements, state); // Real-time preview (disabled for performance)
+  });
+  elements.intensitySlider.addEventListener('change', () => {
+    updateIntensityValue(elements);
     previewCurrentFilter(elements, state);
   });
   elements.contrastSlider.addEventListener('input', () => {
     updateContrastValue(elements);
+    // previewCurrentFilter(elements, state); // Real-time preview (disabled for performance)
+  });
+  elements.contrastSlider.addEventListener('change', () => {
+    updateContrastValue(elements);
     previewCurrentFilter(elements, state);
   });
   elements.brightnessSlider.addEventListener('input', () => {
+    updateBrightnessValue(elements);
+    // previewCurrentFilter(elements, state); // Real-time preview (disabled for performance)
+  });
+  elements.brightnessSlider.addEventListener('change', () => {
     updateBrightnessValue(elements);
     previewCurrentFilter(elements, state);
   });


### PR DESCRIPTION
## Summary
- Render filter preview after slider changes are finalized (`change` event)
- Comment real-time preview logic for easy reactivation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbdc466c4832d96c7cb247fb020e4