### PR TITLE
Add global RGB brightness and contrast adjustments

### DIFF
--- a/js/adjustments.js
+++ b/js/adjustments.js
@@ -1,0 +1,25 @@
+export function applyBrightnessContrast(sourceImg, targetEl, brightness = 0, contrast = 0) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  const width = sourceImg.naturalWidth || sourceImg.width;
+  const height = sourceImg.naturalHeight || sourceImg.height;
+  canvas.width = width;
+  canvas.height = height;
+  ctx.drawImage(sourceImg, 0, 0);
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+
+  const contrastFactor = (259 * (contrast + 255)) / (255 * (259 - contrast));
+  const brightnessOffset = 255 * (brightness / 100);
+
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = Math.max(0, Math.min(255, contrastFactor * (data[i] - 128) + 128 + brightnessOffset));
+    data[i + 1] = Math.max(0, Math.min(255, contrastFactor * (data[i + 1] - 128) + 128 + brightnessOffset));
+    data[i + 2] = Math.max(0, Math.min(255, contrastFactor * (data[i + 2] - 128) + 128 + brightnessOffset));
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  const dataURL = canvas.toDataURL();
+  targetEl.src = dataURL;
+  return dataURL;
+}

--- a/js/filters.js
+++ b/js/filters.js
@@ -1,5 +1,6 @@
 import { showToast } from './toast.js';
 import { applyOrangeTealFilter } from './filters/orangeTeal.js';
+import { applyBrightnessContrast } from './adjustments.js';
 
 export function initFilters(elements, state) {
   elements.filterItems.forEach(item => {
@@ -102,13 +103,28 @@ function applyFilterAdjustment(elements, state) {
     state.appliedFilters.push({ ...state.currentFilter, settings: { ...state.filterSettings } });
   }
   if (state.currentFilter.id === 'orange-teal') {
-    applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, state.filterSettings);
-    state.currentImage = elements.previewImage.src;
-    state.previewBaseImage = null;
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      const result = applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        state.filterSettings.brightness,
+        state.filterSettings.contrast
+      );
+      state.currentImage = result;
+      state.previewBaseImage = null;
+      state.previousSettings = null;
+      closeAdjustmentPanel(elements);
+      showToast('Filter applied successfully', 'success');
+    };
+    applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, {
+      intensity: state.filterSettings.intensity
+    });
+  } else {
+    state.previousSettings = null;
+    closeAdjustmentPanel(elements);
+    showToast('Filter applied successfully', 'success');
   }
-  state.previousSettings = null;
-  closeAdjustmentPanel(elements);
-  showToast('Filter applied successfully', 'success');
 }
 
 function updateIntensityValue(elements) {
@@ -127,9 +143,16 @@ function previewCurrentFilter(elements, state) {
   if (!state.previewBaseImage || !state.currentFilter) return;
   if (state.currentFilter.id === 'orange-teal') {
     const options = {
-      intensity: parseInt(elements.intensitySlider.value, 10),
-      contrast: parseInt(elements.contrastSlider.value, 10),
-      brightness: parseInt(elements.brightnessSlider.value, 10)
+      intensity: parseInt(elements.intensitySlider.value, 10)
+    };
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        parseInt(elements.brightnessSlider.value, 10),
+        parseInt(elements.contrastSlider.value, 10)
+      );
     };
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, options);
   }


### PR DESCRIPTION
## Summary
- Add `applyBrightnessContrast` utility to adjust image brightness and contrast directly in RGB space.
- Update filter workflow to apply global brightness and contrast after Orange & Teal processing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add07a3ff4832d864f8b4921fbcda8