### PR TITLE
refactor: apply global RGB brightness and contrast

### DIFF
--- a/js/adjustments.js
+++ b/js/adjustments.js
@@ -1,0 +1,29 @@
+export function applyBrightnessContrast(sourceImg, targetEl, options = {}) {
+  const { brightness = 0, contrast = 0 } = options;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  const width = sourceImg.naturalWidth || sourceImg.width;
+  const height = sourceImg.naturalHeight || sourceImg.height;
+  canvas.width = width;
+  canvas.height = height;
+  ctx.drawImage(sourceImg, 0, 0);
+
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+
+  const brightnessOffset = 255 * (brightness / 100);
+  const contrastFactor = (259 * (contrast + 255)) / (255 * (259 - contrast));
+
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = clamp(contrastFactor * (data[i] - 128) + 128 + brightnessOffset);
+    data[i + 1] = clamp(contrastFactor * (data[i + 1] - 128) + 128 + brightnessOffset);
+    data[i + 2] = clamp(contrastFactor * (data[i + 2] - 128) + 128 + brightnessOffset);
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  targetEl.src = canvas.toDataURL();
+}
+
+function clamp(value) {
+  return Math.max(0, Math.min(255, value));
+}

--- a/js/filters.js
+++ b/js/filters.js
@@ -1,5 +1,6 @@
 import { showToast } from './toast.js';
 import { applyOrangeTealFilter } from './filters/orangeTeal.js';
+import { applyBrightnessContrast } from './adjustments.js';
 
 export function initFilters(elements, state) {
   elements.filterItems.forEach(item => {
@@ -102,9 +103,23 @@ function applyFilterAdjustment(elements, state) {
     state.appliedFilters.push({ ...state.currentFilter, settings: { ...state.filterSettings } });
   }
   if (state.currentFilter.id === 'orange-teal') {
-    applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, state.filterSettings);
-    state.currentImage = elements.previewImage.src;
-    state.previewBaseImage = null;
+    applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, {
+      intensity: state.filterSettings.intensity
+    });
+    const tempImg = new Image();
+    tempImg.onload = () => {
+      applyBrightnessContrast(tempImg, elements.previewImage, {
+        contrast: state.filterSettings.contrast,
+        brightness: state.filterSettings.brightness
+      });
+      state.currentImage = elements.previewImage.src;
+      state.previewBaseImage = null;
+      state.previousSettings = null;
+      closeAdjustmentPanel(elements);
+      showToast('Filter applied successfully', 'success');
+    };
+    tempImg.src = elements.previewImage.src;
+    return;
   }
   state.previousSettings = null;
   closeAdjustmentPanel(elements);
@@ -127,10 +142,16 @@ function previewCurrentFilter(elements, state) {
   if (!state.previewBaseImage || !state.currentFilter) return;
   if (state.currentFilter.id === 'orange-teal') {
     const options = {
-      intensity: parseInt(elements.intensitySlider.value, 10),
-      contrast: parseInt(elements.contrastSlider.value, 10),
-      brightness: parseInt(elements.brightnessSlider.value, 10)
+      intensity: parseInt(elements.intensitySlider.value, 10)
     };
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, options);
+    const tempImg = new Image();
+    tempImg.onload = () => {
+      applyBrightnessContrast(tempImg, elements.previewImage, {
+        contrast: parseInt(elements.contrastSlider.value, 10),
+        brightness: parseInt(elements.brightnessSlider.value, 10)
+      });
+    };
+    tempImg.src = elements.previewImage.src;
   }
 }


### PR DESCRIPTION
## Summary
- introduce global RGB-based brightness/contrast adjustment utility
- apply orange & teal filter only with intensity and process brightness/contrast globally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add07a3ff4832d864f8b4921fbcda8