### PR TITLE
feat: add black and white filter

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -1,5 +1,6 @@
 import { showToast } from './toast.js';
 import { applyOrangeTealFilter } from './filters/orangeTeal.js';
+import { applyBlackWhiteFilter } from './filters/blackWhite.js';
 import { applyBrightnessContrast } from './adjustments.js';
 
 export function initFilters(elements, state) {
@@ -120,6 +121,24 @@ function applyFilterAdjustment(elements, state) {
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, {
       intensity: state.filterSettings.intensity
     });
+  } else if (state.currentFilter.id === 'black-white') {
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      const result = applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        state.filterSettings.brightness,
+        state.filterSettings.contrast
+      );
+      state.currentImage = result;
+      state.previewBaseImage = null;
+      state.previousSettings = null;
+      closeAdjustmentPanel(elements);
+      showToast('Filter applied successfully', 'success');
+    };
+    applyBlackWhiteFilter(state.previewBaseImage, elements.previewImage, {
+      intensity: state.filterSettings.intensity
+    });
   } else {
     state.previousSettings = null;
     closeAdjustmentPanel(elements);
@@ -155,5 +174,19 @@ function previewCurrentFilter(elements, state) {
       );
     };
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, options);
+  } else if (state.currentFilter.id === 'black-white') {
+    const options = {
+      intensity: parseInt(elements.intensitySlider.value, 10)
+    };
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        parseInt(elements.brightnessSlider.value, 10),
+        parseInt(elements.contrastSlider.value, 10)
+      );
+    };
+    applyBlackWhiteFilter(state.previewBaseImage, elements.previewImage, options);
   }
 }

--- a/js/filters/blackWhite.js
+++ b/js/filters/blackWhite.js
@@ -1,0 +1,45 @@
+export function applyBlackWhiteFilter(sourceImg, targetEl, options = {}) {
+  const { intensity = 100, contrast = 0, brightness = 0 } = options;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  const width = sourceImg.naturalWidth || sourceImg.width;
+  const height = sourceImg.naturalHeight || sourceImg.height;
+  canvas.width = width;
+  canvas.height = height;
+  ctx.drawImage(sourceImg, 0, 0);
+
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+
+  const intensityFactor = intensity / 100;
+  const contrastFactor = (259 * (contrast + 255)) / (255 * (259 - contrast));
+  const brightnessFactor = Math.max(0, 1 + brightness / 100);
+
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+
+    const gray = 0.299 * r + 0.587 * g + 0.114 * b;
+
+    let nr = r * (1 - intensityFactor) + gray * intensityFactor;
+    let ng = g * (1 - intensityFactor) + gray * intensityFactor;
+    let nb = b * (1 - intensityFactor) + gray * intensityFactor;
+
+    nr = contrastFactor * (nr - 128) + 128;
+    ng = contrastFactor * (ng - 128) + 128;
+    nb = contrastFactor * (nb - 128) + 128;
+
+    nr *= brightnessFactor;
+    ng *= brightnessFactor;
+    nb *= brightnessFactor;
+
+    data[i] = Math.max(0, Math.min(255, nr));
+    data[i + 1] = Math.max(0, Math.min(255, ng));
+    data[i + 2] = Math.max(0, Math.min(255, nb));
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  targetEl.src = canvas.toDataURL();
+}


### PR DESCRIPTION
## Summary
- add black & white filter implementation
- integrate filter into adjustments workflow with preview and apply support

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add4d2108c832da8c2d81f66c2fd96