### PR TITLE
Add undo control and confirmation dialogs for destructive actions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -353,6 +353,16 @@
             background-color: var(--tertiary-bg);
         }
 
+        .btn-undo {
+            background-color: transparent;
+            color: var(--secondary-text);
+            border: 1px solid var(--border-color);
+        }
+
+        .btn-undo:hover {
+            background-color: var(--tertiary-bg);
+        }
+
         /* Toast Notification */
         .toast {
             position: fixed;
@@ -386,6 +396,68 @@
 
         .toast.warning {
             background-color: var(--warning-color);
+        }
+
+        /* Confirmation Modal */
+        .confirm-modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            visibility: hidden;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            z-index: 1000;
+        }
+
+        .confirm-modal.show {
+            visibility: visible;
+            opacity: 1;
+        }
+
+        .confirm-content {
+            background-color: var(--secondary-bg);
+            padding: 20px 30px;
+            border-radius: 8px;
+            text-align: center;
+            color: var(--primary-text);
+            min-width: 280px;
+        }
+
+        .confirm-actions {
+            margin-top: 20px;
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+        }
+
+        .confirm-actions .confirm-btn {
+            padding: 8px 16px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            color: #fff;
+        }
+
+        .confirm-actions .confirm-btn#confirmAccept {
+            background-color: var(--success-color);
+        }
+
+        .confirm-actions .confirm-btn#confirmAccept:hover {
+            background-color: #3d8b40;
+        }
+
+        .confirm-actions .confirm-btn.cancel {
+            background-color: var(--danger-color);
+        }
+
+        .confirm-actions .confirm-btn.cancel:hover {
+            background-color: #c23b30;
         }
 
         /* Responsive Design */

--- a/index.html
+++ b/index.html
@@ -158,6 +158,9 @@
         <!-- Footer -->
         <footer class="app-footer">
             <div class="footer-actions">
+                <button class="btn btn-undo" id="undoBtn">
+                    <i class="fas fa-step-backward"></i> Undo
+                </button>
                 <button class="btn btn-reset" id="resetBtn">
                     <i class="fas fa-undo"></i> Reset
                 </button>
@@ -174,6 +177,17 @@
     <div class="toast" id="toast">
         <i class="fas fa-check-circle"></i>
         <span id="toastMessage">Operation successful</span>
+    </div>
+
+    <!-- Confirmation Modal -->
+    <div class="confirm-modal" id="confirmModal">
+        <div class="confirm-content">
+            <p id="confirmMessage">Are you sure?</p>
+            <div class="confirm-actions">
+                <button class="confirm-btn" id="confirmAccept">Accept</button>
+                <button class="confirm-btn cancel" id="confirmCancel">Cancel</button>
+            </div>
+        </div>
     </div>
 
     <script type="module" src="js/main.js"></script>

--- a/js/confirmDialog.js
+++ b/js/confirmDialog.js
@@ -1,0 +1,24 @@
+import { elements } from './elements.js';
+
+export function showConfirm(message, onConfirm) {
+  elements.confirmMessage.textContent = message;
+  elements.confirmModal.classList.add('show');
+
+  function handleAccept() {
+    cleanup();
+    onConfirm();
+  }
+
+  function handleCancel() {
+    cleanup();
+  }
+
+  function cleanup() {
+    elements.confirmAccept.removeEventListener('click', handleAccept);
+    elements.confirmCancel.removeEventListener('click', handleCancel);
+    elements.confirmModal.classList.remove('show');
+  }
+
+  elements.confirmAccept.addEventListener('click', handleAccept);
+  elements.confirmCancel.addEventListener('click', handleCancel);
+}

--- a/js/dragDrop.js
+++ b/js/dragDrop.js
@@ -41,6 +41,9 @@ export function initDragAndDrop(elements, state) {
     const reader = new FileReader();
     reader.onload = function(e) {
       state.currentImage = e.target.result;
+      state.originalImage = e.target.result;
+      state.appliedFilters = [];
+      state.history = [];
       elements.previewImage.src = state.currentImage;
       elements.previewImage.style.display = 'block';
       elements.dropArea.style.display = 'none';

--- a/js/elements.js
+++ b/js/elements.js
@@ -16,7 +16,12 @@ export const elements = {
   brightnessValue: document.getElementById('brightnessValue'),
   downloadBtn: document.getElementById('downloadBtn'),
   resetBtn: document.getElementById('resetBtn'),
+  undoBtn: document.getElementById('undoBtn'),
   newProjectBtn: document.getElementById('newProjectBtn'),
   toast: document.getElementById('toast'),
-  toastMessage: document.getElementById('toastMessage')
+  toastMessage: document.getElementById('toastMessage'),
+  confirmModal: document.getElementById('confirmModal'),
+  confirmMessage: document.getElementById('confirmMessage'),
+  confirmAccept: document.getElementById('confirmAccept'),
+  confirmCancel: document.getElementById('confirmCancel')
 };

--- a/js/filters.js
+++ b/js/filters.js
@@ -92,6 +92,7 @@ function cancelFilterAdjustment(elements, state) {
 }
 
 function applyFilterAdjustment(elements, state) {
+  state.history.push(state.currentImage);
   state.filterSettings = {
     intensity: parseInt(elements.intensitySlider.value, 10),
     contrast: parseInt(elements.contrastSlider.value, 10),

--- a/js/imageActions.js
+++ b/js/imageActions.js
@@ -1,10 +1,20 @@
 import { showToast } from './toast.js';
 import { closeAdjustmentPanel } from './filters.js';
+import { showConfirm } from './confirmDialog.js';
 
 export function initImageActions(elements, state) {
   elements.downloadBtn.addEventListener('click', () => downloadImage(state));
-  elements.resetBtn.addEventListener('click', () => resetImage(elements, state));
-  elements.newProjectBtn.addEventListener('click', () => newProject(elements, state));
+  elements.resetBtn.addEventListener('click', () => {
+    if (!state.currentImage) {
+      showToast('No image to reset', 'warning');
+      return;
+    }
+    showConfirm('Reset image to original?', () => resetImage(elements, state));
+  });
+  elements.newProjectBtn.addEventListener('click', () => {
+    showConfirm('Load a new image? Current changes will be lost.', () => newProject(elements, state));
+  });
+  elements.undoBtn.addEventListener('click', () => undoLastFilter(elements, state));
 }
 
 function downloadImage(state) {
@@ -16,28 +26,46 @@ function downloadImage(state) {
 }
 
 function resetImage(elements, state) {
-  if (!state.currentImage) {
-    showToast('No image to reset', 'warning');
-    return;
-  }
   state.appliedFilters = [];
+  state.history = [];
   elements.filterItems.forEach(item => item.classList.remove('active'));
   state.currentFilter = null;
   state.previewBaseImage = null;
+  state.previousSettings = null;
+  state.currentImage = state.originalImage;
+  elements.previewImage.src = state.originalImage;
   closeAdjustmentPanel(elements);
   showToast('Image reset successfully', 'success');
 }
 
 function newProject(elements, state) {
   state.currentImage = null;
+  state.originalImage = null;
   state.currentFilter = null;
   state.appliedFilters = [];
   state.previousSettings = null;
   state.previewBaseImage = null;
+  state.history = [];
 
   elements.previewImage.style.display = 'none';
   elements.dropArea.style.display = 'flex';
   elements.filterItems.forEach(item => item.classList.remove('active'));
   closeAdjustmentPanel(elements);
   showToast('New project created', 'success');
+}
+
+function undoLastFilter(elements, state) {
+  if (state.history.length === 0) {
+    showToast('Nothing to undo', 'warning');
+    return;
+  }
+  const previous = state.history.pop();
+  state.appliedFilters.pop();
+  state.currentImage = previous;
+  elements.previewImage.src = previous;
+  elements.filterItems.forEach(item => item.classList.remove('active'));
+  state.currentFilter = null;
+  state.previewBaseImage = null;
+  closeAdjustmentPanel(elements);
+  showToast('Last action undone', 'success');
 }

--- a/js/state.js
+++ b/js/state.js
@@ -1,5 +1,6 @@
 export const state = {
   currentImage: null,
+  originalImage: null,
   previewBaseImage: null,
   currentFilter: null,
   filterSettings: {
@@ -8,5 +9,6 @@ export const state = {
     brightness: 0
   },
   previousSettings: null,
-  appliedFilters: []
+  appliedFilters: [],
+  history: []
 };


### PR DESCRIPTION
## Summary
- Add Undo button and history stack to revert filters step-by-step
- Restore original image on reset and confirm before resetting or starting new projects
- Introduce reusable dark-themed confirmation modal with colored action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/confirmDialog.js js/imageActions.js js/dragDrop.js js/elements.js js/filters.js js/state.js`


------
https://chatgpt.com/codex/tasks/task_e_68add6bd65dc832da7ce02906e6f2894