### PR TITLE
Implement image download and hide button during preview

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -56,6 +56,7 @@ function selectFilter(filterItem, elements, state) {
 function openAdjustmentPanel(filterName, elements, state) {
   elements.adjustmentTitle.textContent = `${filterName} Adjustment`;
   elements.adjustmentsSidebar.classList.add('active');
+  elements.downloadBtn.style.display = 'none';
   if (state.previousSettings && state.previousSettings.filterId === state.currentFilter.id) {
     elements.intensitySlider.value = state.previousSettings.intensity;
     elements.contrastSlider.value = state.previousSettings.contrast;
@@ -76,6 +77,7 @@ function openAdjustmentPanel(filterName, elements, state) {
 
 export function closeAdjustmentPanel(elements) {
   elements.adjustmentsSidebar.classList.remove('active');
+  elements.downloadBtn.style.display = 'flex';
 }
 
 function cancelFilterAdjustment(elements, state) {

--- a/js/imageActions.js
+++ b/js/imageActions.js
@@ -26,6 +26,18 @@ function downloadImage(state) {
     showToast('No image to download', 'warning');
     return;
   }
+  const link = document.createElement('a');
+  link.href = state.currentImage;
+  const match = state.currentImage.match(/^data:(image\/\w+);/);
+  let extension = 'png';
+  if (match) {
+    const mime = match[1].split('/')[1];
+    extension = mime === 'jpeg' ? 'jpg' : mime;
+  }
+  link.download = `image.${extension}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
   showToast('Image downloaded successfully', 'success');
 }
 


### PR DESCRIPTION
## Summary
- implement actual image download using data URLs
- hide download button while adjustments are in preview mode

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add91eeb2c832d9b897bff2ad4e645