### PR TITLE
style: add divider before custom sliders

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -234,6 +234,12 @@
             margin-bottom: 25px;
         }
 
+        #customSliders:not(:empty) {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid var(--border-color);
+        }
+
         .control-label {
             display: flex;
             justify-content: space-between;


### PR DESCRIPTION
## Summary
- Separate custom sliders from default adjustments with a subtle top border and spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3e4fbf8832d846ef9dbf0bef887