### PR TITLE
feat: enable manual slider value input

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ scalabilità.
 Apri `index.html` in un browser moderno e trascina un'immagine nell'area centrale.
 Seleziona un filtro dal pannello di sinistra e regola i parametri nel pannello di destra.
 Puoi scaricare l'immagine o creare un nuovo progetto dalle azioni presenti nel footer.
+
+Per impostare manualmente i valori dei cursori, fai clic sul numero accanto allo slider,
+inserisci il valore desiderato e premi Enter o clicca fuori dall'input per confermare.
+Un clic con il tasto destro sullo slider ripristina il valore di default.

--- a/css/styles.css
+++ b/css/styles.css
@@ -287,6 +287,16 @@
             font-size: 14px;
         }
 
+        .slider-value input {
+            width: 100%;
+            box-sizing: border-box;
+            background: var(--secondary-bg);
+            border: 1px solid var(--tertiary-bg);
+            color: var(--primary-text);
+            font-size: 14px;
+            text-align: right;
+        }
+
         .adjustment-actions {
             display: flex;
             gap: 10px;

--- a/js/filters.js
+++ b/js/filters.js
@@ -13,6 +13,41 @@ const sliderConfigs = {
   ]
 };
 
+function enableValueEdit(slider, valueSpan, onChange, elements, state) {
+  valueSpan.addEventListener('click', () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = slider.min;
+    input.max = slider.max;
+    input.value = slider.value;
+    valueSpan.textContent = '';
+    valueSpan.appendChild(input);
+    input.focus();
+    input.select();
+    const commit = () => {
+      let val = parseInt(input.value, 10);
+      if (isNaN(val)) val = parseInt(slider.value, 10);
+      val = Math.max(parseInt(slider.min, 10), Math.min(parseInt(slider.max, 10), val));
+      slider.value = val;
+      onChange();
+      previewCurrentFilter(elements, state);
+    };
+    input.addEventListener('blur', commit);
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        input.blur();
+      }
+    });
+  });
+
+  slider.addEventListener('contextmenu', e => {
+    e.preventDefault();
+    slider.value = slider.defaultValue;
+    onChange();
+    previewCurrentFilter(elements, state);
+  });
+}
+
 export function initFilters(elements, state) {
   elements.filterItems.forEach(item => {
     item.addEventListener('click', () => selectFilter(item, elements, state));
@@ -48,6 +83,28 @@ export function initFilters(elements, state) {
     updateBrightnessValue(elements);
     previewCurrentFilter(elements, state);
   });
+
+  enableValueEdit(
+    elements.intensitySlider,
+    elements.intensityValue,
+    () => updateIntensityValue(elements),
+    elements,
+    state
+  );
+  enableValueEdit(
+    elements.contrastSlider,
+    elements.contrastValue,
+    () => updateContrastValue(elements),
+    elements,
+    state
+  );
+  enableValueEdit(
+    elements.brightnessSlider,
+    elements.brightnessValue,
+    () => updateBrightnessValue(elements),
+    elements,
+    state
+  );
 }
 
 function setupCustomSliders(filterId, elements, state) {
@@ -75,6 +132,7 @@ function setupCustomSliders(filterId, elements, state) {
     input.min = cfg.min;
     input.max = cfg.max;
     input.value = state.customSettings[cfg.name] ?? cfg.default;
+    input.defaultValue = cfg.default;
     input.className = 'slider';
     input.id = `${cfg.name}Slider`;
     sliderContainer.appendChild(input);
@@ -95,6 +153,7 @@ function setupCustomSliders(filterId, elements, state) {
       update();
       previewCurrentFilter(elements, state);
     });
+    enableValueEdit(input, valueSpan, update, elements, state);
   });
 }
 


### PR DESCRIPTION
## Summary
- allow numeric editing of sliders with automatic clamping
- add context-menu reset to default for all sliders
- document manual input feature and add input styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adf55450c4832daafef6179c66fac7