### PR TITLE
Add high contrast filter inspired by film 300

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ scalabilità.
   - `dragDrop.js`: gestione del caricamento dell'immagine tramite drag & drop.
   - `adjustments.js`: applica regolazioni di luminosità e contrasto all'immagine.
   - `filters.js`: logica per la selezione dei filtri e la regolazione dei parametri.
-  - `filters/`: implementazioni dei singoli filtri (es. `blackWhite.js`, `orangeTeal.js`).
+  - `filters/`: implementazioni dei singoli filtri (es. `blackWhite.js`, `orangeTeal.js`, `highContrast.js`).
   - `imageActions.js`: azioni sull'immagine (download, reset, nuovo progetto).
   - `confirmDialog.js`: finestra di conferma personalizzata per le azioni dell'utente.
   - `toast.js`: notifiche testuali.

--- a/js/filters.js
+++ b/js/filters.js
@@ -1,5 +1,6 @@
 import { showToast } from './toast.js';
 import { applyOrangeTealFilter } from './filters/orangeTeal.js';
+import { applyHighContrastFilter } from './filters/highContrast.js';
 import { applyBlackWhiteFilter } from './filters/blackWhite.js';
 import { applyVintageFilter } from './filters/vintage.js';
 import { applyBrightnessContrast } from './adjustments.js';
@@ -247,6 +248,24 @@ function applyFilterAdjustment(elements, state) {
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, {
       intensity: state.filterSettings.intensity
     });
+  } else if (state.currentFilter.id === 'high-contrast') {
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      const result = applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        state.filterSettings.brightness,
+        state.filterSettings.contrast
+      );
+      state.currentImage = result;
+      state.previewBaseImage = null;
+      state.previousSettings = null;
+      closeAdjustmentPanel(elements);
+      showToast('Filter applied successfully', 'success');
+    };
+    applyHighContrastFilter(state.previewBaseImage, elements.previewImage, {
+      intensity: state.filterSettings.intensity
+    });
   } else if (state.currentFilter.id === 'black-white') {
     elements.previewImage.onload = () => {
       elements.previewImage.onload = null;
@@ -322,6 +341,20 @@ function previewCurrentFilter(elements, state) {
       );
     };
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, options);
+  } else if (state.currentFilter.id === 'high-contrast') {
+    const options = {
+      intensity: parseInt(elements.intensitySlider.value, 10)
+    };
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        parseInt(elements.brightnessSlider.value, 10),
+        parseInt(elements.contrastSlider.value, 10)
+      );
+    };
+    applyHighContrastFilter(state.previewBaseImage, elements.previewImage, options);
   } else if (state.currentFilter.id === 'black-white') {
     const options = {
       intensity: parseInt(elements.intensitySlider.value, 10)

--- a/js/filters/highContrast.js
+++ b/js/filters/highContrast.js
@@ -1,0 +1,56 @@
+export function applyHighContrastFilter(sourceImg, targetEl, options = {}) {
+  const { intensity = 100, contrast = 0, brightness = 0 } = options;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  const width = sourceImg.naturalWidth || sourceImg.width;
+  const height = sourceImg.naturalHeight || sourceImg.height;
+  canvas.width = width;
+  canvas.height = height;
+  ctx.drawImage(sourceImg, 0, 0);
+
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+
+  const intensityFactor = intensity / 100;
+  const contrastFactor = (259 * (contrast + 255)) / (255 * (259 - contrast));
+  const brightnessFactor = Math.max(0, 1 + brightness / 100);
+
+  const overlay = (base, blend) => {
+    const b = base / 255;
+    const d = blend / 255;
+    const result = b < 0.5 ? 2 * b * d : 1 - 2 * (1 - b) * (1 - d);
+    return result * 255;
+  };
+
+  for (let i = 0; i < data.length; i += 4) {
+    const r0 = data[i];
+    const g0 = data[i + 1];
+    const b0 = data[i + 2];
+
+    const gray = 0.299 * r0 + 0.587 * g0 + 0.114 * b0;
+
+    let nr = overlay(r0, gray);
+    let ng = overlay(g0, gray);
+    let nb = overlay(b0, gray);
+
+    nr = r0 * (1 - intensityFactor) + nr * intensityFactor;
+    ng = g0 * (1 - intensityFactor) + ng * intensityFactor;
+    nb = b0 * (1 - intensityFactor) + nb * intensityFactor;
+
+    nr = contrastFactor * (nr - 128) + 128;
+    ng = contrastFactor * (ng - 128) + 128;
+    nb = contrastFactor * (nb - 128) + 128;
+
+    nr *= brightnessFactor;
+    ng *= brightnessFactor;
+    nb *= brightnessFactor;
+
+    data[i] = Math.max(0, Math.min(255, nr));
+    data[i + 1] = Math.max(0, Math.min(255, ng));
+    data[i + 2] = Math.max(0, Math.min(255, nb));
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  targetEl.src = canvas.toDataURL();
+}


### PR DESCRIPTION
## Summary
- implement 300-style high contrast filter using grey overlay blending
- wire filter into filter selection and preview logic
- document new filter in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adfb0aab3c832d903864900834b369