### PR TITLE
Add sharpen and vignette filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ scalabilità.
   - `dragDrop.js`: gestione del caricamento dell'immagine tramite drag & drop.
   - `adjustments.js`: applica regolazioni di luminosità e contrasto all'immagine.
   - `filters.js`: logica per la selezione dei filtri e la regolazione dei parametri.
-  - `filters/`: implementazioni dei singoli filtri (es. `blackWhite.js`, `highContrast.js`, `orangeTeal.js`, `sepia.js`, `coolTone.js`, `blur.js`).
+  - `filters/`: implementazioni dei singoli filtri (es. `blackWhite.js`, `highContrast.js`, `orangeTeal.js`, `sepia.js`, `coolTone.js`, `blur.js`, `sharpen.js`, `vignette.js`).
   - `imageActions.js`: azioni sull'immagine (download, reset, nuovo progetto).
   - `confirmDialog.js`: finestra di conferma personalizzata per le azioni dell'utente.
   - `toast.js`: notifiche testuali.

--- a/js/filters.js
+++ b/js/filters.js
@@ -6,6 +6,8 @@ import { applyVintageFilter } from './filters/vintage.js';
 import { applySepiaFilter } from './filters/sepia.js';
 import { applyCoolToneFilter } from './filters/coolTone.js';
 import { applyBlurFilter } from './filters/blur.js';
+import { applySharpenFilter } from './filters/sharpen.js';
+import { applyVignetteFilter } from './filters/vignette.js';
 import { applyBrightnessContrast } from './adjustments.js';
 
 const sliderConfigs = {
@@ -341,6 +343,42 @@ function applyFilterAdjustment(elements, state) {
     applyBlurFilter(state.previewBaseImage, elements.previewImage, {
       intensity: state.filterSettings.intensity
     });
+  } else if (state.currentFilter.id === 'sharpen') {
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      const result = applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        state.filterSettings.brightness,
+        state.filterSettings.contrast
+      );
+      state.currentImage = result;
+      state.previewBaseImage = null;
+      state.previousSettings = null;
+      closeAdjustmentPanel(elements);
+      showToast('Filter applied successfully', 'success');
+    };
+    applySharpenFilter(state.previewBaseImage, elements.previewImage, {
+      intensity: state.filterSettings.intensity
+    });
+  } else if (state.currentFilter.id === 'vignette') {
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      const result = applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        state.filterSettings.brightness,
+        state.filterSettings.contrast
+      );
+      state.currentImage = result;
+      state.previewBaseImage = null;
+      state.previousSettings = null;
+      closeAdjustmentPanel(elements);
+      showToast('Filter applied successfully', 'success');
+    };
+    applyVignetteFilter(state.previewBaseImage, elements.previewImage, {
+      intensity: state.filterSettings.intensity
+    });
   } else if (state.currentFilter.id === 'vintage') {
       elements.previewImage.onload = () => {
         elements.previewImage.onload = null;
@@ -468,6 +506,34 @@ function previewCurrentFilter(elements, state) {
       );
     };
     applyBlurFilter(state.previewBaseImage, elements.previewImage, options);
+  } else if (state.currentFilter.id === 'sharpen') {
+    const options = {
+      intensity: parseInt(elements.intensitySlider.value, 10)
+    };
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        parseInt(elements.brightnessSlider.value, 10),
+        parseInt(elements.contrastSlider.value, 10)
+      );
+    };
+    applySharpenFilter(state.previewBaseImage, elements.previewImage, options);
+  } else if (state.currentFilter.id === 'vignette') {
+    const options = {
+      intensity: parseInt(elements.intensitySlider.value, 10)
+    };
+    elements.previewImage.onload = () => {
+      elements.previewImage.onload = null;
+      applyBrightnessContrast(
+        elements.previewImage,
+        elements.previewImage,
+        parseInt(elements.brightnessSlider.value, 10),
+        parseInt(elements.contrastSlider.value, 10)
+      );
+    };
+    applyVignetteFilter(state.previewBaseImage, elements.previewImage, options);
   } else if (state.currentFilter.id === 'vintage') {
       const options = {
         intensity: parseInt(elements.intensitySlider.value, 10),

--- a/js/filters/sharpen.js
+++ b/js/filters/sharpen.js
@@ -1,0 +1,42 @@
+export function applySharpenFilter(sourceImg, targetEl, options = {}) {
+  const { intensity = 100 } = options;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  const width = sourceImg.naturalWidth || sourceImg.width;
+  const height = sourceImg.naturalHeight || sourceImg.height;
+  canvas.width = width;
+  canvas.height = height;
+
+  // Draw the original image
+  ctx.drawImage(sourceImg, 0, 0, width, height);
+  const originalData = ctx.getImageData(0, 0, width, height);
+
+  // Create a blurred version of the image using Gaussian blur
+  const blurCanvas = document.createElement('canvas');
+  const blurCtx = blurCanvas.getContext('2d');
+  blurCanvas.width = width;
+  blurCanvas.height = height;
+  const blurRadius = 2; // typical radius for professional unsharp masking
+  blurCtx.filter = `blur(${blurRadius}px)`;
+  blurCtx.drawImage(sourceImg, 0, 0, width, height);
+  const blurredData = blurCtx.getImageData(0, 0, width, height);
+
+  const data = originalData.data;
+  const blurData = blurredData.data;
+  const amount = (intensity / 100) * 1.5; // scale sharpening amount
+
+  for (let i = 0; i < data.length; i += 4) {
+    // Unsharp mask: add scaled high frequency detail
+    data[i] = clamp(data[i] + (data[i] - blurData[i]) * amount);
+    data[i + 1] = clamp(data[i + 1] + (data[i + 1] - blurData[i + 1]) * amount);
+    data[i + 2] = clamp(data[i + 2] + (data[i + 2] - blurData[i + 2]) * amount);
+  }
+
+  ctx.putImageData(originalData, 0, 0);
+  targetEl.src = canvas.toDataURL();
+}
+
+function clamp(value) {
+  return Math.max(0, Math.min(255, value));
+}

--- a/js/filters/vignette.js
+++ b/js/filters/vignette.js
@@ -1,0 +1,35 @@
+export function applyVignetteFilter(sourceImg, targetEl, options = {}) {
+  const { intensity = 100 } = options;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  const width = sourceImg.naturalWidth || sourceImg.width;
+  const height = sourceImg.naturalHeight || sourceImg.height;
+  canvas.width = width;
+  canvas.height = height;
+
+  ctx.drawImage(sourceImg, 0, 0, width, height);
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+
+  const cx = width / 2;
+  const cy = height / 2;
+  const maxDist = Math.sqrt(cx * cx + cy * cy);
+  const strength = (intensity / 100) * 0.75; // maximum edge darkening
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const vignette = 1 - strength * Math.pow(dist / maxDist, 2);
+      const index = (y * width + x) * 4;
+      data[index] *= vignette;
+      data[index + 1] *= vignette;
+      data[index + 2] *= vignette;
+    }
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  targetEl.src = canvas.toDataURL();
+}


### PR DESCRIPTION
## Summary
- implement sharpen filter using unsharp mask for crisp detail
- add vignette filter with radial darkening
- wire new filters into preview and apply workflow and update documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe062e88832db89863bd11bfd4ee