### PR TITLE
Rename Vintage filter to Vintage 80s

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
                         </div>
                         <span class="filter-name">Orange & Teal</span>
                     </div>
-                    <div class="filter-item" data-filter="vintage">
+                    <div class="filter-item" data-filter="vintage-80s">
                         <div class="filter-icon" style="background: linear-gradient(to right, #d4a574, #ff8b0b);">
                             <i class="fas fa-adjust" style="color: white;"></i>
                         </div>
-                        <span class="filter-name">Vintage</span>
+                        <span class="filter-name">Vintage 80s</span>
                     </div>
                     <div class="filter-item" data-filter="high-contrast">
                         <div class="filter-icon" style="background: linear-gradient(to right, #000, #a80000);">

--- a/js/filters.js
+++ b/js/filters.js
@@ -2,7 +2,7 @@ import { showToast } from './toast.js';
 import { applyOrangeTealFilter } from './filters/orangeTeal.js';
 import { applyBlackWhiteFilter } from './filters/blackWhite.js';
 import { applyHighContrastFilter } from './filters/highContrast.js';
-import { applyVintageFilter } from './filters/vintage.js';
+import { applyVintage80sFilter } from './filters/vintage80s.js';
 import { applySepiaFilter } from './filters/sepia.js';
 import { applyCoolToneFilter } from './filters/coolTone.js';
 import { applyBlurFilter } from './filters/blur.js';
@@ -15,7 +15,7 @@ import { applyBigSurFilter } from './filters/bigSur.js';
 import { applyBrightnessContrast } from './adjustments.js';
 
 const sliderConfigs = {
-  //vintage: [
+  //'vintage-80s': [
   //  { name: 'alpha', label: 'Alpha', min: -100, max: 100, default: 0 },
   //  { name: 'beta', label: 'Beta', min: -50, max: 50, default: 0 },
   //  { name: 'gamma', label: 'Gamma', min: -50, max: 50, default: 0 },
@@ -485,7 +485,7 @@ function applyFilterAdjustment(elements, state) {
       showToast('Filter applied successfully', 'success');
     };
     applyBigSurFilter(state.previewBaseImage, elements.previewImage, options);
-  } else if (state.currentFilter.id === 'vintage') {
+  } else if (state.currentFilter.id === 'vintage-80s') {
       elements.previewImage.onload = () => {
         elements.previewImage.onload = null;
         const result = applyBrightnessContrast(
@@ -500,7 +500,7 @@ function applyFilterAdjustment(elements, state) {
       closeAdjustmentPanel(elements);
       showToast('Filter applied successfully', 'success');
     };
-    applyVintageFilter(state.previewBaseImage, elements.previewImage, {
+    applyVintage80sFilter(state.previewBaseImage, elements.previewImage, {
       intensity: state.filterSettings.intensity,
       alpha: state.filterSettings.alpha || 0,
       beta: state.filterSettings.beta || 0,
@@ -717,7 +717,7 @@ function previewCurrentFilter(elements, state) {
       );
     };
     applyBigSurFilter(state.previewBaseImage, elements.previewImage, options);
-  } else if (state.currentFilter.id === 'vintage') {
+  } else if (state.currentFilter.id === 'vintage-80s') {
       const options = {
         intensity: parseInt(elements.intensitySlider.value, 10),
         alpha: state.customSettings.alpha || 0,
@@ -734,6 +734,6 @@ function previewCurrentFilter(elements, state) {
         parseInt(elements.contrastSlider.value, 10)
       );
     };
-    applyVintageFilter(state.previewBaseImage, elements.previewImage, options);
+    applyVintage80sFilter(state.previewBaseImage, elements.previewImage, options);
   }
 }

--- a/js/filters/vintage80s.js
+++ b/js/filters/vintage80s.js
@@ -1,5 +1,5 @@
-// Vintage filter converted from Python implementation
-// Applies a classic vintage color grading with soft light blend and color tweaks
+// Vintage 80s filter converted from Python implementation
+// Applies a classic vintage 80s color grading with soft light blend and color tweaks
 
 function softLight(base, blend) {
   const b = base / 255;
@@ -60,7 +60,7 @@ function hsvToRgb(h, s, v) {
   return [(r1 + m) * 255, (g1 + m) * 255, (b1 + m) * 255];
 }
 
-export function applyVintageFilter(sourceImg, targetEl, options = {}) {
+export function applyVintage80sFilter(sourceImg, targetEl, options = {}) {
   const {
     intensity = 100,
     alpha = 0,


### PR DESCRIPTION
## Summary
- rename Vintage filter to Vintage 80s across the app
- update imports and function names to use `applyVintage80sFilter`
- adjust filter application logic for new `vintage-80s` identifier

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af0c964ebc832d97bfcd3d5a7f6dd8