### PR TITLE
feat: add optional orange teal v2 filter

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -189,11 +189,20 @@ function openAdjustmentPanel(filterName, elements, state) {
     elements.contrastSlider.value = state.previousSettings.contrast;
     elements.brightnessSlider.value = state.previousSettings.brightness;
     state.customSettings = { ...state.previousSettings.customSettings };
+    if (
+      state.currentFilter.id === 'orange-teal' &&
+      state.customSettings.version === undefined
+    ) {
+      state.customSettings.version = 2;
+    }
   } else {
     elements.intensitySlider.value = 100;
     elements.contrastSlider.value = 0;
     elements.brightnessSlider.value = 0;
     state.customSettings = {};
+    if (state.currentFilter.id === 'orange-teal') {
+      state.customSettings.version = 2;
+    }
   }
   updateIntensityValue(elements);
   updateContrastValue(elements);
@@ -255,7 +264,8 @@ function applyFilterAdjustment(elements, state) {
       showToast('Filter applied successfully', 'success');
     };
     applyOrangeTealFilter(state.previewBaseImage, elements.previewImage, {
-      intensity: state.filterSettings.intensity
+      intensity: state.filterSettings.intensity,
+      version: state.filterSettings.version
     });
   } else if (state.currentFilter.id === 'black-white') {
     elements.previewImage.onload = () => {
@@ -530,7 +540,8 @@ function previewCurrentFilter(elements, state) {
   if (!state.previewBaseImage || !state.currentFilter) return;
   if (state.currentFilter.id === 'orange-teal') {
     const options = {
-      intensity: parseInt(elements.intensitySlider.value, 10)
+      intensity: parseInt(elements.intensitySlider.value, 10),
+      version: state.customSettings.version
     };
     elements.previewImage.onload = () => {
       elements.previewImage.onload = null;

--- a/js/filters/orangeTeal.js
+++ b/js/filters/orangeTeal.js
@@ -1,7 +1,7 @@
 // Orange & Teal filter converted from Python implementation
 // Applies a smooth orange and teal color grading to an image element
 
-// Build lookup tables for hue shift and saturation boost
+// Build lookup tables for hue shift and saturation boost (version 1)
 function buildOrangeTealLUT(
   sigmaH = 15,
   warmH = 17, //original 15
@@ -36,7 +36,67 @@ function buildOrangeTealLUT(
   return { hueLut, satLut };
 }
 
-const { hueLut: HUE_LUT, satLut: SAT_LUT } = buildOrangeTealLUT();
+// Build lookup tables for hue shift and saturation boost (version 2)
+function buildOrangeTealLUTv2(
+  sigmaH = 20,
+  warmH = 15,
+  coolH = 90,
+  pinkH = 150,
+  satBoostWarm = 1.45,
+  satBoostCool = 1.20,
+  satBoostPink = 1.25
+) {
+  const hueLut = new Array(180).fill(0);
+  const satLut = new Array(180).fill(1.0);
+  const twoSigma2 = 2 * sigmaH * sigmaH;
+
+  const warmRad = (warmH * 2 * Math.PI) / 180;
+  const coolRad = (coolH * 2 * Math.PI) / 180;
+  const pinkRad = (pinkH * 2 * Math.PI) / 180;
+
+  for (let h = 0; h < 180; h++) {
+    const dw = Math.min(Math.abs(h - warmH), 180 - Math.abs(h - warmH));
+    const dc = Math.min(Math.abs(h - coolH), 180 - Math.abs(h - coolH));
+    const dp = Math.min(Math.abs(h - pinkH), 180 - Math.abs(h - pinkH));
+
+    let wWarm = Math.exp(-(dw * dw) / twoSigma2);
+    let wCool = Math.exp(-(dc * dc) / twoSigma2);
+    let wPink = Math.exp(-(dp * dp) / twoSigma2);
+
+    const wSum = wWarm + wCool + wPink;
+
+    if (wSum < 1e-6) {
+      hueLut[h] = h;
+      satLut[h] = 1.0;
+    } else {
+      wWarm /= wSum;
+      wCool /= wSum;
+      wPink /= wSum;
+
+      const avgX =
+        wWarm * Math.cos(warmRad) +
+        wCool * Math.cos(coolRad) +
+        wPink * Math.cos(pinkRad);
+      const avgY =
+        wWarm * Math.sin(warmRad) +
+        wCool * Math.sin(coolRad) +
+        wPink * Math.sin(pinkRad);
+
+      let newHueDeg = (Math.atan2(avgY, avgX) * 180) / Math.PI;
+      if (newHueDeg < 0) newHueDeg += 360;
+      const newHue = Math.round(newHueDeg / 2) % 180;
+
+      hueLut[h] = newHue;
+      satLut[h] =
+        wWarm * satBoostWarm + wCool * satBoostCool + wPink * satBoostPink;
+    }
+  }
+
+  return { hueLut, satLut };
+}
+
+const LUT_V1 = buildOrangeTealLUT();
+const LUT_V2 = buildOrangeTealLUTv2();
 
 // Smooth contrast adjustment similar to the Python _smooth_contrast
 function smoothContrast(v, midBoost = 1.05, shadowMul = 0.93, hiMul = 1.06) {
@@ -95,7 +155,10 @@ function hsvToRgb(h, s, v) {
 }
 
 export function applyOrangeTealFilter(sourceImg, targetEl, options = {}) {
-  const { intensity = 100, contrast = 0, brightness = 0 } = options;
+  const { intensity = 100, contrast = 0, brightness = 0, version = 1 } = options;
+
+  const { hueLut: HUE_LUT, satLut: SAT_LUT } =
+    version === 2 ? LUT_V2 : LUT_V1;
 
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- add second Orange & Teal LUT with pink/purple tolerance and revised tone values
- allow choosing filter version via `version` option (defaults to v2 when selected)
- wire filter panel to pass version to filter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af44c42550832d80d210697d244da9