### PR TITLE
Add Orange & Teal filter version 3

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -193,7 +193,7 @@ function openAdjustmentPanel(filterName, elements, state) {
       state.currentFilter.id === 'orange-teal' &&
       state.customSettings.version === undefined
     ) {
-      state.customSettings.version = 2;
+      state.customSettings.version = 3;
     }
   } else {
     elements.intensitySlider.value = 100;
@@ -201,7 +201,7 @@ function openAdjustmentPanel(filterName, elements, state) {
     elements.brightnessSlider.value = 0;
     state.customSettings = {};
     if (state.currentFilter.id === 'orange-teal') {
-      state.customSettings.version = 2;
+      state.customSettings.version = 3;
     }
   }
   updateIntensityValue(elements);

--- a/js/filters/orangeTeal.js
+++ b/js/filters/orangeTeal.js
@@ -95,8 +95,67 @@ function buildOrangeTealLUTv2(
   return { hueLut, satLut };
 }
 
+function buildOrangeTealLUTv3(
+  sigmaH = 20,
+  warmH = 17,
+  coolH = 94,
+  pinkH = 140,
+  satBoostWarm = 1.45,
+  satBoostCool = 1.20,
+  satBoostPink = 1.25
+) {
+  const hueLut = new Array(180).fill(0);
+  const satLut = new Array(180).fill(1.0);
+  const twoSigma2 = 2 * sigmaH * sigmaH;
+
+  const warmRad = (warmH * 2 * Math.PI) / 180;
+  const coolRad = (coolH * 2 * Math.PI) / 180;
+  const pinkRad = (pinkH * 2 * Math.PI) / 180;
+
+  for (let h = 0; h < 180; h++) {
+    const dw = Math.min(Math.abs(h - warmH), 180 - Math.abs(h - warmH));
+    const dc = Math.min(Math.abs(h - coolH), 180 - Math.abs(h - coolH));
+    const dp = Math.min(Math.abs(h - pinkH), 180 - Math.abs(h - pinkH));
+
+    let wWarm = Math.exp(-(dw * dw) / twoSigma2);
+    let wCool = Math.exp(-(dc * dc) / twoSigma2);
+    let wPink = Math.exp(-(dp * dp) / twoSigma2);
+
+    const wSum = wWarm + wCool + wPink;
+
+    if (wSum < 1e-6) {
+      hueLut[h] = h;
+      satLut[h] = 1.0;
+    } else {
+      wWarm /= wSum;
+      wCool /= wSum;
+      wPink /= wSum;
+
+      const avgX =
+        wWarm * Math.cos(warmRad) +
+        wCool * Math.cos(coolRad) +
+        wPink * Math.cos(pinkRad);
+      const avgY =
+        wWarm * Math.sin(warmRad) +
+        wCool * Math.sin(coolRad) +
+        wPink * Math.sin(pinkRad);
+
+      let newHueDeg = (Math.atan2(avgY, avgX) * 180) / Math.PI;
+      if (newHueDeg < 0) newHueDeg += 360;
+      const newHue = Math.round(newHueDeg / 2) % 180;
+
+      hueLut[h] = newHue;
+      satLut[h] =
+        wWarm * satBoostWarm + wCool * satBoostCool + wPink * satBoostPink;
+    }
+  }
+
+  return { hueLut, satLut };
+}
+
 const LUT_V1 = buildOrangeTealLUT();
 const LUT_V2 = buildOrangeTealLUTv2();
+const LUT_V3 = buildOrangeTealLUTv3();
 
 // Smooth contrast adjustment similar to the Python _smooth_contrast
 function smoothContrast(v, midBoost = 1.05, shadowMul = 0.93, hiMul = 1.06) {
@@ -156,9 +215,8 @@ function hsvToRgb(h, s, v) {
 
 export function applyOrangeTealFilter(sourceImg, targetEl, options = {}) {
   const { intensity = 100, contrast = 0, brightness = 0, version = 1 } = options;
-
   const { hueLut: HUE_LUT, satLut: SAT_LUT } =
-    version === 2 ? LUT_V2 : LUT_V1;
+    version === 3 ? LUT_V3 : version === 2 ? LUT_V2 : LUT_V1;
 
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- implement Orange & Teal LUT v3 and expose it in filter processing
- default Orange & Teal filter selection to version 3

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5c10b7e8832d914da1ce0eac0e95